### PR TITLE
Create matching rule for simapro flows with country code in name

### DIFF
--- a/flowmapper/flowmap.py
+++ b/flowmapper/flowmap.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 from .flow import Flow
-from .match import match_rules
+from .match import match_rules, format_match_result
 from tqdm import tqdm
 from typing import Callable
 
@@ -27,17 +27,26 @@ class Flowmap:
                     is_match = rule(s, t)
                     if is_match:
                         result.append(
-                            {'from': s.id,
-                             'to': t.id,
+                            {'from': s,
+                             'to': t,
                              'info': is_match}
                         )
                         break
         self.mappings = result
         self.mappings_count = len(result)
-        self.mapped_source_flows = len({link['from'] for link in result})
+        self.mapped_source_flows = len({link['from'].id for link in result})
         self.statistics()
     
     def statistics(self):
         print(f'{self.source_flows_unique_count} unique source flows...')
         print(f'{self.target_flows_unique_count} unique target flows...')
         print(f'{self.mappings_count} mappings of {self.mapped_source_flows} unique source flows ({self.mapped_source_flows / self.source_flows_unique_count:.2%} of total).')
+
+    def to_randonneur(self):
+        result = [
+            format_match_result(map_entry['from'], 
+                                map_entry['to'],
+                                map_entry['info']) 
+            for map_entry in self.mappings
+        ]
+        return result

--- a/flowmapper/match.py
+++ b/flowmapper/match.py
@@ -7,7 +7,7 @@ from .constants import (
     RANDOM_NAME_DIFFERENCES_MAPPING,
 )
 from .flow import Flow
-from .utils import rm_parentheses_roman_numerals
+from .utils import rm_parentheses_roman_numerals, extract_country_code
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,15 @@ def match_mapped_name_differences(s: Flow, t: Flow, mapping, comment = 'Mapped n
 def match_names_with_roman_numerals_in_parentheses(s: Flow, t: Flow, comment = 'With/without roman numerals in parentheses'):
     is_match = rm_parentheses_roman_numerals(s.name) == rm_parentheses_roman_numerals(t.name) and s.context == t.context
     result = format_match_result(s, t, comment = comment, is_match = is_match)
+    return result
+
+def match_names_with_country_codes(s: Flow, t: Flow, comment = 'Names with country code'):
+    s_name, s_location = extract_country_code(s.name)
+    if s_location:
+        is_match = s_name == t.name and s.context == t.context
+    else:
+        is_match = False
+    result = format_match_result(s, t, comment = f'{comment} {s_location}', is_match = is_match)
     return result
 
 def match_resources_with_suffix_in_ground(s: Flow, t: Flow):

--- a/flowmapper/match.py
+++ b/flowmapper/match.py
@@ -12,32 +12,29 @@ from .utils import rm_parentheses_roman_numerals, extract_country_code
 logger = logging.getLogger(__name__)
 
 def format_match_result(s: Flow, t: Flow, match_info: dict):
-    if match_info['is_match']:
-        source_context_key = s.fields['context'] if isinstance(s.fields['context'], str) else s.fields['context'][0].split('.')[0]
-        source_result = {
-                    s.fields['name']: s.name,
-                    source_context_key: s.raw[source_context_key]
-                }
-        if s.uuid:
-            source_result.update({s.fields['uuid']: s.uuid})
-        
-        target_result = {
-                    'uuid': t.uuid,
-                    'name': t.name,
-                    'context': t.context.full,
-                    'unit': t.unit
-                }
-        if match_info.get('location'):
-            target_result.update({'location': match_info['location']})
-
-        result = {
-                'source': source_result,
-                'target': target_result,
-                'conversionFactor': 1 if s.unit == t.unit else '?',
-                'comment': match_info['comment']
+    source_context_key = s.fields['context'] if isinstance(s.fields['context'], str) else s.fields['context'][0].split('.')[0]
+    source_result = {
+                s.fields['name']: s.name,
+                source_context_key: s.raw[source_context_key]
             }
-    else:
-        result = None
+    if s.uuid:
+        source_result.update({s.fields['uuid']: s.uuid})
+    
+    target_result = {
+                'uuid': t.uuid,
+                'name': t.name,
+                'context': t.context.full,
+                'unit': t.unit
+            }
+    if match_info.get('location'):
+        target_result.update({'location': match_info['location']})
+
+    result = {
+            'source': source_result,
+            'target': target_result,
+            'conversionFactor': 1 if s.unit == t.unit else '?',
+            'comment': match_info['comment']
+        }
     return result
 
 def match_identical_cas_numbers(s: Flow, t: Flow, comment: str = 'Identical CAS numbers'):    

--- a/flowmapper/match.py
+++ b/flowmapper/match.py
@@ -42,41 +42,39 @@ def format_match_result(s: Flow, t: Flow, match_info: dict):
 
 def match_identical_cas_numbers(s: Flow, t: Flow, comment: str = 'Identical CAS numbers'):    
     is_match = s.cas == t.cas and s.context == t.context
-
-    result = format_match_result(s, t, {'comment': comment, 'is_match': is_match})
-    return result
+    if is_match:
+        return {'comment': comment}
 
 def match_identical_names(s: Flow, t: Flow, comment = 'Identical names'):
     is_match = s.name == t.name and s.context == t.context
     
-    result = format_match_result(s, t, {'comment': comment, 'is_match': is_match})
-    return result
+    if is_match:
+        return {'comment': comment}
 
 def match_identical_names_except_missing_suffix(s: Flow, t: Flow, suffix, comment = 'Identical names except missing suffix'):
     is_match = f"{s.name}, {suffix}" == t.name and s.context == t.context
     
-    result = format_match_result(s, t, {'comment': comment, 'is_match': is_match})
-    return result
+    if is_match:
+        return {'comment': comment}
 
 def match_mapped_name_differences(s: Flow, t: Flow, mapping, comment = 'Mapped name differences'):    
     is_match = mapping.get(s.name) == t.name and s.context == t.context
     
-    result = format_match_result(s, t, {'comment': comment, 'is_match': is_match})
-    return result
+    if is_match:
+        return {'comment': comment}
 
 def match_names_with_roman_numerals_in_parentheses(s: Flow, t: Flow, comment = 'With/without roman numerals in parentheses'):
     is_match = rm_parentheses_roman_numerals(s.name) == rm_parentheses_roman_numerals(t.name) and s.context == t.context
-    result = format_match_result(s, t, {'comment': comment, 'is_match': is_match})
-    return result
+    
+    if is_match:
+        return {'comment': comment}
 
 def match_names_with_country_codes(s: Flow, t: Flow, comment = 'Names with country code'):
     s_name, s_location = extract_country_code(s.name)
-    if s_location:
-        is_match = s_name == t.name and s.context == t.context
-    else:
-        is_match = False
-    result = format_match_result(s, t, {'is_match': is_match, 'comment': comment, 'location': s_location})
-    return result
+    is_match = s_location and s_name == t.name and s.context == t.context
+    
+    if is_match:
+        return {'comment': comment, 'location': s_location}
 
 def match_resources_with_suffix_in_ground(s: Flow, t: Flow):
     return match_identical_names_except_missing_suffix(s, t, suffix = 'in ground', comment = 'Resources with suffix in ground')

--- a/flowmapper/match.py
+++ b/flowmapper/match.py
@@ -96,5 +96,7 @@ def match_rules():
             match_emissions_with_suffix_ion,
             match_minor_land_name_differences,
             match_missing_fossil_and_biogenic_carbon,
+            match_names_with_roman_numerals_in_parentheses,
+            match_names_with_country_codes,
             match_identical_cas_numbers,
     ]

--- a/flowmapper/utils.py
+++ b/flowmapper/utils.py
@@ -42,3 +42,16 @@ def read_flowlist(filepath: Path):
 def rm_parentheses_roman_numerals(x):
     pattern = r'\(\s*([IVXLCDM]+)\s*\)'
     return re.sub(pattern, r'\1', x)
+
+
+def extract_country_code(s: str) -> tuple[str, None | str]:
+    # Regex to find a two-letter uppercase code following a comma and optional whitespace
+    match = re.search(r',\s*([A-Z]{2})$', s)
+
+    if match:
+        # Extract the country code and the preceding part of the string
+        country_code = match.group(1)
+        rest_of_string = s[:match.start()].strip()
+        return (rest_of_string, country_code)
+    else:
+        return (s, None)

--- a/flowmapper/utils.py
+++ b/flowmapper/utils.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import hashlib
 import re
+from typing import Optional
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -44,7 +45,7 @@ def rm_parentheses_roman_numerals(x):
     return re.sub(pattern, r'\1', x)
 
 
-def extract_country_code(s: str) -> tuple[str, None | str]:
+def extract_country_code(s: str) -> tuple[str, Optional[str]]:
     # Regex to find a two-letter uppercase code following a comma and optional whitespace
     match = re.search(r',\s*([A-Z]{2})$', s)
 

--- a/tests/test_extract_country_code.py
+++ b/tests/test_extract_country_code.py
@@ -1,0 +1,16 @@
+from flowmapper.utils import extract_country_code
+
+def test_with_valid_country_code():
+    assert extract_country_code('Ammonia, NL') == ('Ammonia', 'NL')
+
+def test_with_invalid_country_code_lowercase():
+    assert extract_country_code('Ammonia, nl') == ('Ammonia, nl', None)
+
+def test_with_no_country_code():
+    assert extract_country_code('Ammonia') == ('Ammonia', None)
+
+def test_with_additional_text():
+    assert extract_country_code('Ammonia, NL something') == ('Ammonia, NL something', None)
+
+def test_with_space_before_country_code():
+    assert extract_country_code('Ammonia,   NL') == ('Ammonia', 'NL')

--- a/tests/test_flowmap.py
+++ b/tests/test_flowmap.py
@@ -10,15 +10,6 @@ def test_flowmap(source_flows, target_flows):
             "from": "9b680160081438f81d551c724c30b09b",
             "to": "70e4b1b6b6604811cb46114962a4d003",
             "info": {
-                "source": {
-                    "name": "1,4-Butanediol",
-                    "categories": ["Air", "(unspecified)"],
-                },
-                "target": {"uuid": "09db39be-d9a6-4fc3-8d25-1f80b23e9131",
-                           'name': '1,4-Butanediol',
-                           'context': 'air/unspecified', 
-                           'unit': 'kg'},
-                "conversionFactor": 1,
                 "comment": "Identical names",
             },
         }
@@ -41,15 +32,6 @@ def test_flowmap_with_custom_rules_match(source_flows, target_flows):
             "from": "9b680160081438f81d551c724c30b09b",
             "to": "70e4b1b6b6604811cb46114962a4d003",
             "info": {
-                "source": {
-                    "name": "1,4-Butanediol",
-                    "categories": ["Air", "(unspecified)"],
-                },
-                "target": {"uuid": "09db39be-d9a6-4fc3-8d25-1f80b23e9131",
-                           'name': '1,4-Butanediol',
-                           'context': 'air/unspecified', 
-                           'unit': 'kg'},
-                "conversionFactor": 1,
                 "comment": "Identical names",
             },
         }

--- a/tests/test_flowmap.py
+++ b/tests/test_flowmap.py
@@ -1,39 +1,64 @@
 from flowmapper.flowmap import Flowmap
-from flowmapper.match import match_emissions_with_suffix_ion, match_minor_land_name_differences, match_identical_names
+from flowmapper.match import (
+    match_emissions_with_suffix_ion,
+    match_minor_land_name_differences,
+    match_identical_names,
+)
+
 
 def test_flowmap(source_flows, target_flows):
     flowmap = Flowmap(source_flows, target_flows)
     flowmap.match()
-    actual = flowmap.mappings
+    actual = flowmap.to_randonneur()
     expected = [
         {
-            "from": "9b680160081438f81d551c724c30b09b",
-            "to": "70e4b1b6b6604811cb46114962a4d003",
-            "info": {
-                "comment": "Identical names",
+            "source": {
+                "name": "1,4-Butanediol",
+                "categories": ["Air", "(unspecified)"],
             },
+            "target": {
+                "uuid": "09db39be-d9a6-4fc3-8d25-1f80b23e9131",
+                "name": "1,4-Butanediol",
+                "context": "air/unspecified",
+                "unit": "kg",
+            },
+            "conversionFactor": 1,
+            "comment": "Identical names",
         }
     ]
     assert actual == expected
 
+
 def test_flowmap_with_custom_rules_no_match(source_flows, target_flows):
-    flowmap = Flowmap(source_flows, target_flows, rules=[match_emissions_with_suffix_ion, match_minor_land_name_differences])
+    flowmap = Flowmap(
+        source_flows,
+        target_flows,
+        rules=[match_emissions_with_suffix_ion, match_minor_land_name_differences],
+    )
     flowmap.match()
     actual = flowmap.mappings
     expected = []
     assert actual == expected
 
+
 def test_flowmap_with_custom_rules_match(source_flows, target_flows):
     flowmap = Flowmap(source_flows, target_flows, rules=[match_identical_names])
     flowmap.match()
-    actual = flowmap.mappings
+    actual = flowmap.to_randonneur()
     expected = [
         {
-            "from": "9b680160081438f81d551c724c30b09b",
-            "to": "70e4b1b6b6604811cb46114962a4d003",
-            "info": {
-                "comment": "Identical names",
+            "source": {
+                "name": "1,4-Butanediol",
+                "categories": ["Air", "(unspecified)"],
             },
+            "target": {
+                "uuid": "09db39be-d9a6-4fc3-8d25-1f80b23e9131",
+                "name": "1,4-Butanediol",
+                "context": "air/unspecified",
+                "unit": "kg",
+            },
+            "conversionFactor": 1,
+            "comment": "Identical names",
         }
     ]
     assert actual == expected

--- a/tests/test_format_match_result.py
+++ b/tests/test_format_match_result.py
@@ -34,7 +34,7 @@ def test_format_match_result_missing_id():
 
     t = Flow.from_dict(target, target_fields)
 
-    actual = format_match_result(s, t, is_match=True, comment="foo")
+    actual = format_match_result(s, t, {'is_match': True, 'comment': 'foo'})
     expected = {'source': {'name': 'Carbon dioxide, in air', 'context': 'Raw materials'}, 
                 'target': {'uuid': 'cc6a1abb-b123-4ca6-8f16-38209df609be', 
                            'name': 'Carbon dioxide, in air',

--- a/tests/test_match_names_with_country_codes.py
+++ b/tests/test_match_names_with_country_codes.py
@@ -1,7 +1,5 @@
 from flowmapper.flow import Flow
-from flowmapper.context import Context
 from flowmapper.match import match_names_with_country_codes
-
 
 def test_match_names_with_country_codes():
     fields = {"name": "name", "context": "context"}
@@ -10,9 +8,6 @@ def test_match_names_with_country_codes():
 
     actual = match_names_with_country_codes(s, t)
     expected = {
-        "source": {"name": "Ammonia, NL", "context": "air"},
-        "target": {"uuid": None, "name": "Ammonia", "context": "air", "unit": None, "location": "NL"},
-        "conversionFactor": 1,
-        "comment": "Names with country code",
+        "comment": "Names with country code", "location": "NL"
     }
     assert actual == expected

--- a/tests/test_match_names_with_country_codes.py
+++ b/tests/test_match_names_with_country_codes.py
@@ -1,0 +1,18 @@
+from flowmapper.flow import Flow
+from flowmapper.context import Context
+from flowmapper.match import match_names_with_country_codes
+
+
+def test_match_names_with_country_codes():
+    fields = {"name": "name", "context": "context"}
+    s = Flow.from_dict({"name": "Ammonia, NL", "context": "air"}, fields)
+    t = Flow.from_dict({"name": "Ammonia", "context": "air"}, fields)
+
+    actual = match_names_with_country_codes(s, t)
+    expected = {
+        "source": {"name": "Ammonia, NL", "context": "air"},
+        "target": {"uuid": None, "name": "Ammonia", "context": "air", "unit": None},
+        "conversionFactor": 1,
+        "comment": "Names with country code NL",
+    }
+    assert actual == expected

--- a/tests/test_match_names_with_country_codes.py
+++ b/tests/test_match_names_with_country_codes.py
@@ -11,8 +11,8 @@ def test_match_names_with_country_codes():
     actual = match_names_with_country_codes(s, t)
     expected = {
         "source": {"name": "Ammonia, NL", "context": "air"},
-        "target": {"uuid": None, "name": "Ammonia", "context": "air", "unit": None},
+        "target": {"uuid": None, "name": "Ammonia", "context": "air", "unit": None, "location": "NL"},
         "conversionFactor": 1,
-        "comment": "Names with country code NL",
+        "comment": "Names with country code",
     }
     assert actual == expected


### PR DESCRIPTION
Closes #14

- initial match_names_with_country_codes implementation
- add location to target flows when matched by match_names_with_country_codes
- match functions return only matching information
- add method Flowmap.to_randonneur
- add new match rules
